### PR TITLE
Fix Mac installRelease issue with installation of APK files with spaces.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,10 @@ gen/
 
 # Gradle files
 .gradle/
+gradle/
 build/
+gradlew
+gradlew.bat
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/Purple Robot/build.gradle
+++ b/Purple Robot/build.gradle
@@ -1,3 +1,5 @@
+import com.android.builder.core.DefaultManifestParser
+
 buildscript {
     repositories {
         mavenCentral()
@@ -89,6 +91,15 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-project.pro'
             signingConfig signingConfigs.release
             debuggable false
+
+            applicationVariants.all { variant ->
+                variant.outputs.each { output ->
+                    def file = output.outputFile
+                    def manifestParser = new DefaultManifestParser()
+                    def String versionName = manifestParser.getVersionName((File) android.sourceSets.main.manifest.srcFile)
+                    output.outputFile = new File(file.parent, file.name.replace(".apk", "-" + versionName + ".apk").replace(" ", "-").toLowerCase())
+                }
+            }
         }
         debug {
             minifyEnabled true


### PR DESCRIPTION
- Replaced APK spaces with dashes.
- Made APK name lower case.
- Added manifest defined version number to APK name.
- Added Android Studio auto-generated files to ignore file.
